### PR TITLE
docs: position YarDB as microservice persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A document-oriented database with a RESTful Web API, implemented in C++23. YarDB
 
 Microservices usually own one dataset (or a small set of related collections). YarDB matches that shape:
 
-- **One service → one `yardb` process → one database file** — collections for that service live together; other services get their own file and process
-- **Single writer is enough** — an exclusive `.pid` lock and in-process write serialization fit a service that is the sole owner of its data
-- **Scale out by services, not by clustering one DB** — add more microservices (each with its own YarDB), rather than turning one deployment into a multi-tenant enterprise store
+- **One service owns one dataset** — that service’s collections live in its own YarDB deployment; other services get their own
+- **Parallel, fault-tolerant instances per service** — the aim is several `yardb` instances for the same microservice (throughput and failover), not a single process forever
+- **Not a shared enterprise store** — do not put unrelated domains into one deployment; scale new domains by adding services, each with its own YarDB
 
-YarDB is a poor fit when many unrelated domains must share one database, or when you need built-in multi-node replication and failover for a single shared store. For the operational model and current limits, see the [deployment guide](docs/deployment.md).
+Today each open database file still has a single writer (exclusive `.pid` lock). Parallelism and fault tolerance across instances for one service are the intended direction; see the [deployment guide](docs/deployment.md) for the current model and gaps.
 
 ## Overview
 
@@ -128,7 +128,7 @@ An interactive and pipeable HTTP client. See [yarsh program documentation](docs/
 
 ### yarproxy - HTTP Fan-out Proxy
 
-A development HTTP fan-out proxy for independent `yardb` instances, not replication or HA. See [yarproxy program documentation](docs/programs.md#yarproxy---http-fan-out-proxy).
+A development HTTP fan-out proxy for independent `yardb` instances. Parallel / fault-tolerant multi-instance operation per microservice is the aim; `yarproxy` is not that production path yet. See [yarproxy program documentation](docs/programs.md#yarproxy---http-fan-out-proxy).
 
 ### yarexport / yarimport - Export, Import, Compaction
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # YarDB - Yet Another RESTful Database
 
-A document-oriented database with a RESTful Web API, implemented in C++23. YarDB is a persistence layer for microservices, not a shared enterprise database for monoliths.
+A document-oriented database with a RESTful Web API, implemented in C++23. YarDB is mainly targeted as a persistence layer for microservices; it can be used elsewhere, but that is the design sweet spot.
 
 **Project Structure**: This project follows [P1204R0: Canonical Project Structure](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1204r0.html) guidelines for C++ projects.
 
 ## Intended use
 
-Microservices usually own one dataset (or a small set of related collections). YarDB matches that shape:
+YarDB is mainly targeted at microservice persistence. Microservices usually own one dataset (or a few related collections), so a small deployment with parallel, fault-tolerant instances is typically enough:
 
-- **One service owns one dataset** — that service’s collections live in its own YarDB deployment; other services get their own
-- **Parallel, fault-tolerant instances per service** — the aim is several `yardb` instances for the same microservice (throughput and failover), not a single process forever
-- **Not a shared enterprise store** — do not put unrelated domains into one deployment; scale new domains by adding services, each with its own YarDB
+- **Primary fit**: one service owns its data in its own YarDB deployment; other services get their own
+- **Per-service aim**: several `yardb` instances for the same microservice (throughput and failover)
+- **Weaker fit**: a single shared store for many unrelated domains (classic monolith / multi-tenant enterprise DB). That is not the main target; prefer separate deployments when domains are independent
 
-Today each open database file still has a single writer (exclusive `.pid` lock). Parallelism and fault tolerance across instances for one service are the intended direction; see the [deployment guide](docs/deployment.md) for the current model and gaps.
+Today each open database file still has a single writer (exclusive `.pid` lock). Parallelism and fault tolerance across instances for one service remain the intended direction; see the [deployment guide](docs/deployment.md) for the current model and gaps.
 
 ## Overview
 
@@ -128,7 +128,7 @@ An interactive and pipeable HTTP client. See [yarsh program documentation](docs/
 
 ### yarproxy - HTTP Fan-out Proxy
 
-A development HTTP fan-out proxy for independent `yardb` instances. Parallel / fault-tolerant multi-instance operation per microservice is the aim; `yarproxy` is not that production path yet. See [yarproxy program documentation](docs/programs.md#yarproxy---http-fan-out-proxy).
+A development HTTP fan-out proxy for independent `yardb` instances. Parallel / fault-tolerant multi-instance operation (mainly per microservice) is the aim; `yarproxy` is not that production path yet. See [yarproxy program documentation](docs/programs.md#yarproxy---http-fan-out-proxy).
 
 ### yarexport / yarimport - Export, Import, Compaction
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # YarDB - Yet Another RESTful Database
 
-A document-oriented database with a RESTful Web API, implemented in C++23. YarDB is intended for development, testing, and controlled single-node deployments; see the [deployment guide](docs/deployment.md) for current operational limitations.
+A document-oriented database with a RESTful Web API, implemented in C++23. YarDB is a persistence layer for microservices, not a shared enterprise database for monoliths.
 
 **Project Structure**: This project follows [P1204R0: Canonical Project Structure](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1204r0.html) guidelines for C++ projects.
+
+## Intended use
+
+Microservices usually own one dataset (or a small set of related collections). YarDB matches that shape:
+
+- **One service → one `yardb` process → one database file** — collections for that service live together; other services get their own file and process
+- **Single writer is enough** — an exclusive `.pid` lock and in-process write serialization fit a service that is the sole owner of its data
+- **Scale out by services, not by clustering one DB** — add more microservices (each with its own YarDB), rather than turning one deployment into a multi-tenant enterprise store
+
+YarDB is a poor fit when many unrelated domains must share one database, or when you need built-in multi-node replication and failover for a single shared store. For the operational model and current limits, see the [deployment guide](docs/deployment.md).
 
 ## Overview
 
@@ -126,7 +136,7 @@ Export FSON records as JSONL (`yarexport`, including `--live` for current docs o
 
 ## Operations
 
-Database locking, recovery behavior, backups, request limits, and production constraints are documented in the [Deployment Guide](docs/deployment.md).
+The intended one-service / one-file model, database locking, recovery, backups, request limits, and production constraints are documented in the [Deployment Guide](docs/deployment.md).
 
 ## Dependencies
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ See **[changelog.md](changelog.md)**, the single source of truth for shipped fea
 ## 📖 Reading Guide
 
 ### New to YarDB?
-1. Start with root **[README.md](../README.md)** for overview and **intended use** (microservice persistence, not enterprise shared DB)
+1. Start with root **[README.md](../README.md)** for overview and **intended use** (per-microservice persistence with parallel/fault-tolerant instances; not an enterprise shared DB)
 2. Read **[programs.md](programs.md)** to understand available tools
 3. Check **[development.md](development.md)** for build/test instructions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,27 +33,27 @@ See **[changelog.md](changelog.md)**, the single source of truth for shipped fea
 ## 📖 Reading Guide
 
 ### New to YarDB?
-1. Start with root **[README.md](../README.md)** for project overview
+1. Start with root **[README.md](../README.md)** for overview and **intended use** (microservice persistence, not enterprise shared DB)
 2. Read **[programs.md](programs.md)** to understand available tools
 3. Check **[development.md](development.md)** for build/test instructions
 
 ### Contributing?
-1. Review **[development.md](development.md)** for development workflows
+1. Review **[development.md](development.md)** for development workflows and architecture decisions
 2. See **[project_organization.md](project_organization.md)** for code organization
 3. Check **[changelog.md](changelog.md)** for what already shipped
 4. Check **[archive/](archive/)** for historical documentation and completed proposals
 
 ### Operating YarDB?
-1. Read **[programs.md](programs.md)** for detailed command documentation
-2. Check **[deployment.md](deployment.md)** for production deployment
+1. Read **[deployment.md](deployment.md#target-deployment-model)** for the one-service / one-file model
+2. Read **[programs.md](programs.md)** for detailed command documentation
 3. Monitor **[development.md](development.md)** roadmap for upcoming features
 
 ## 📝 Documentation Principles
 
-1. **Root README.md** - Concise project overview and entry point
+1. **Root README.md** - Concise project overview, intended use, and entry point
 2. **programs.md** - Canonical executable and HTTP API behavior
-3. **deployment.md** - Canonical operational, security, backup, and recovery guidance
-4. **development.md** - Contributor workflow and active roadmap
+3. **deployment.md** - Canonical operational model, security, backup, and recovery guidance
+4. **development.md** - Contributor workflow, architecture decisions, and active roadmap
 5. **changelog.md** - Canonical shipped-work log and current verification totals
 6. **archive/** - Historical evaluations and completed proposals; never the current reference
 7. **Link instead of copying** - Keep detailed facts in their canonical document

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ See **[changelog.md](changelog.md)**, the single source of truth for shipped fea
 ## 📖 Reading Guide
 
 ### New to YarDB?
-1. Start with root **[README.md](../README.md)** for overview and **intended use** (per-microservice persistence with parallel/fault-tolerant instances; not an enterprise shared DB)
+1. Start with root **[README.md](../README.md)** for overview and **intended use** (mainly microservice persistence with parallel/fault-tolerant instances)
 2. Read **[programs.md](programs.md)** to understand available tools
 3. Check **[development.md](development.md)** for build/test instructions
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,17 +2,17 @@
 
 ## Target deployment model
 
-YarDB is aimed at microservice persistence, not at monolithic or multi-tenant enterprise databases. Within each microservice, the aim is still **parallel and fault-tolerant YarDB instances** for that service’s dataset.
+YarDB is mainly targeted as microservice persistence. Other uses are fine when they match the same shape (one owner, one or a few datasets). Within that primary case, the aim is still parallel and fault-tolerant YarDB instances for that owner’s dataset.
 
-| Assumption | Consequence |
-|------------|-------------|
-| One microservice owns one (or a few related) datasets | That service gets its own YarDB deployment; unrelated domains do not share it |
-| The service needs throughput and uptime | Run multiple `yardb` instances for that service (parallelism + fault tolerance), not only a single process |
-| Domains stay isolated | New domains → new services with their own YarDB; not one shared cluster for the whole enterprise |
+| Typical assumption (main target) | Consequence |
+|----------------------------------|-------------|
+| One microservice owns one (or a few related) datasets | Give that owner its own YarDB deployment |
+| The owner needs throughput and uptime | Run multiple `yardb` instances for that dataset (parallelism + fault tolerance) |
+| Domains are independent | Prefer separate deployments per owner rather than one shared store for many domains |
 
-Keep each service’s data private to that service (loopback + reverse proxy, or network policy). Do not put unrelated domains into one deployment “for convenience.”
+Keep each owner’s data private where practical (loopback + reverse proxy, or network policy). Stuffing unrelated domains into one deployment “for convenience” is a weaker fit for how YarDB is designed.
 
-**Today vs aim:** each open database file still has one writer (exclusive `{database}.pid` lock). `yarproxy` can fan out HTTP to independent backends for development, but does not yet provide production-grade replication or failover. Parallel / fault-tolerant instances *per microservice* remain the product direction.
+**Today vs aim:** each open database file still has one writer (exclusive `{database}.pid` lock). `yarproxy` can fan out HTTP to independent backends for development, but does not yet provide production-grade replication or failover. Parallel / fault-tolerant instances for a given owner’s dataset remain the product direction.
 
 ## 🚀 Production Readiness Status
 
@@ -21,15 +21,14 @@ Keep each service’s data private to that service (loopback + reverse proxy, or
 - ✅ Document storage and retrieval
 - ✅ OData query support
 - ⚠️ **Partial**: Bearer PAT MVP (data + admin for `/_*`), safe bind defaults (`127.0.0.1`, public bind requires PAT), liveness/readiness probes, minimum Prometheus `/metrics`, `correlation_id` tracing, exclusive database locking, startup validation, truncated-tail recovery, and a 1 MiB request limit
-- ❌ **Missing for hardened per-service deploys**: JWT/OAuth2, full RBAC, TLS at reverse proxy, richer ops automation
-- ❌ **Missing for parallel / fault-tolerant instances per service**: production-grade replication, failover, and consistent multi-instance semantics (see below)
-- ❌ **Out of target model**: multi-tenant shared databases spanning unrelated domains
+- ❌ **Missing for hardened deploys**: JWT/OAuth2, full RBAC, TLS at reverse proxy, richer ops automation
+- ❌ **Missing for parallel / fault-tolerant instances**: production-grade replication, failover, and consistent multi-instance semantics (see below)
 
 **Production Requirements** (see [development roadmap](../docs/development.md)):
 - 🔐 **Security & Authentication** (data + admin PATs shipped; JWT/RBAC and TLS at reverse proxy still planned; safe bind defaults shipped)
 - 📊 **Monitoring & Observability** (minimum Prometheus `/metrics` shipped; richer labels / tracing planned; liveness/readiness probes shipped)
 - 🛡️ **Production Hardening** (graceful shutdown, resource limits)
-- 🔁 **Per-service parallelism & fault tolerance** (multiple instances for one microservice’s dataset)
+- 🔁 **Parallelism & fault tolerance** (multiple instances for one owner’s dataset — the main microservice case)
 
 ## 🏗️ Building for Production
 
@@ -238,20 +237,20 @@ Point-in-time recovery is not implemented yet. Stop `yardb` before copying, expo
 
 ## 🚨 Availability & Scaling
 
-### By design (microservice model)
-- **Data ownership boundary**: one microservice → one YarDB deployment (its collections). Unrelated domains stay in other deployments.
-- **Aim per service**: several parallel, fault-tolerant `yardb` instances for that service’s dataset (throughput + failover).
+### Main target (microservice-shaped ownership)
+- **Ownership boundary**: one owner (typically a microservice) → one YarDB deployment for its collections. Prefer separate deployments when domains are independent.
+- **Aim per owner**: several parallel, fault-tolerant `yardb` instances for that dataset (throughput + failover).
 - **Today**: one writer per open database file (exclusive `.pid` lock); `yarproxy` is HTTP fan-out for independent backends in development — not production replication/HA yet (see [programs.md](programs.md#yarproxy---http-fan-out-proxy))
 - **Manual backup/compact**: `yarexport` / `yarimport` (no automated PITR)
 
-### Roadmap (per microservice)
-- Replication and automatic failover among instances that serve the same service dataset
+### Roadmap (per owner / per microservice)
+- Replication and automatic failover among instances that serve the same dataset
 - Production-grade proxy: health checks, partial-failure reporting, and clear read/write consistency (including read-your-writes where required)
-- Automated backups and retention for each service deployment
+- Automated backups and retention for each deployment
 
-### Not the product target
-- Multi-tenant “one YarDB for the whole enterprise” spanning unrelated domains
-- Treating many domains as one shared logical database
+### Weaker fit (not the main target)
+- One shared YarDB for many unrelated domains (monolith-style or multi-tenant enterprise store)
+- Expecting enterprise shared-DB features that assume that model
 
 ## 🔧 Runtime Requirements
 
@@ -309,14 +308,14 @@ sar -n DEV 1
 - [ ] **Security**: Bind to private interfaces (or explicit public bind with PAT); enable Bearer PAT (`--pat` / `--pat-file`); add TLS at reverse proxy
 - [ ] **Monitoring**: Set up metrics collection and alerting
 - [ ] **Backup**: Configure regular backup procedures
-- [ ] **One deployment per service**: Map each microservice to its own YarDB data (do not share a store across unrelated services)
+- [ ] **Ownership boundary**: Prefer one YarDB deployment per owner (e.g. per microservice); avoid stuffing unrelated domains into one store unless you accept the weaker fit
 - [ ] **Instance lock awareness**: Until multi-instance semantics ship, ensure one process owns each open database file and document the stale-lock runbook
 - [ ] **Client limits**: Ensure clients keep request bodies within the 1 MiB limit
-- [ ] **Parallelism & fault tolerance**: Plan for multiple instances per microservice when the service needs them; today use explicit ops patterns, and track the per-service HA roadmap above
-- [ ] **Performance**: Load test within the expected per-service dataset size
+- [ ] **Parallelism & fault tolerance**: Plan for multiple instances when the owner needs them; today use explicit ops patterns, and track the HA roadmap above
+- [ ] **Performance**: Load test within the expected dataset size for that deployment
 - [ ] **Documentation**: Update runbooks and procedures
 
 ---
 
-**⚠️ Important**: YarDB is still hardening for production (auth, TLS at the proxy, multi-instance semantics, ops automation). Even when ready, treat it as per-service persistence with parallel/fault-tolerant instances *for that service* — not as a shared enterprise database for many domains.
+**⚠️ Important**: YarDB is still hardening for production (auth, TLS at the proxy, multi-instance semantics, ops automation). It is mainly targeted at per-owner (typically microservice) persistence with parallel/fault-tolerant instances for that owner’s data — a weaker fit as a shared enterprise database for many domains.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,13 +1,26 @@
 # YarDB Production Deployment Guide
 
+## Target deployment model
+
+YarDB is aimed at microservice persistence, not at monolithic or multi-tenant enterprise databases.
+
+| Assumption | Consequence |
+|------------|-------------|
+| One microservice owns one (or a few related) datasets | One `yardb` process and one `--file` database per service is the normal layout |
+| The service is the sole writer of its data | An exclusive `{database}.pid` lock and in-process write serialization are by design, not temporary gaps |
+| Scale comes from more services | Deploy another service with its own YarDB instance; do not expect one shared cluster for many domains |
+
+Keep each service’s database private to that service (loopback + reverse proxy, or network policy). Do not put unrelated domains into one file “for convenience.”
+
 ## 🚀 Production Readiness Status
 
-**Current State**: **Development/Testing** - Not yet production-ready
+**Current State**: **Development/Testing** - Not yet production-ready for unattended production use
 - ✅ Basic HTTP server with REST API
 - ✅ Document storage and retrieval
 - ✅ OData query support
 - ⚠️ **Partial**: Bearer PAT MVP (data + admin for `/_*`), safe bind defaults (`127.0.0.1`, public bind requires PAT), liveness/readiness probes, minimum Prometheus `/metrics`, `correlation_id` tracing, exclusive database locking, startup validation, truncated-tail recovery, and a 1 MiB request limit
-- ❌ **Missing**: JWT/OAuth2, full RBAC, TLS at reverse proxy, high availability
+- ❌ **Missing for hardened single-service deploys**: JWT/OAuth2, full RBAC, TLS at reverse proxy, richer ops automation
+- ❌ **Out of target model** (not a near-term product goal): multi-tenant shared databases, built-in multi-node HA for one logical store
 
 **Production Requirements** (see [development roadmap](../docs/development.md)):
 - 🔐 **Security & Authentication** (data + admin PATs shipped; JWT/RBAC and TLS at reverse proxy still planned; safe bind defaults shipped)
@@ -219,18 +232,23 @@ Point-in-time recovery is not implemented yet. Stop `yardb` before copying, expo
 - **Log Files**: Syslog or application logs
 - **Temp Space**: For large query operations
 
-## 🚨 High Availability & Scaling
+## 🚨 Availability & Scaling
 
-### Current Limitations
-- **Single Node**: Each `yardb` process owns one database file; no built-in clustering
-- **`yarproxy`**: Round-robin reads and write fan-out only — independent DBs, no sync, no guaranteed consistency (see [programs.md](programs.md#yarproxy---http-fan-out-proxy))
-- **Manual backup/compact only**: `yarexport` / `yarimport` (no automated PITR)
+### By design (microservice model)
+- **Single writer per database file**: Each `yardb` process owns one `--file`; exclusive `.pid` lock. Enough when one microservice owns that data.
+- **Scale out by service**: New domains get new services and new database files, not a bigger shared YarDB cluster.
+- **`yarproxy`**: Dev/test HTTP fan-out across independent backends only — not replication or HA (see [programs.md](programs.md#yarproxy---http-fan-out-proxy))
+- **Manual backup/compact**: `yarexport` / `yarimport` (no automated PITR)
 
-### Future HA Features (Roadmap)
-- **Multi-node Replication** with automatic failover and conflict handling
-- **Production-grade proxy** with health checks, partial-failure reporting, and read-your-writes semantics
-- **Automated Backups** with retention policies
-- **Horizontal Scaling** support
+### Still useful for single-service production
+- Automated backups and retention for each service’s file
+- Clear stale-lock and restore runbooks
+- Reverse-proxy TLS, PAT (or later JWT), and probes already outlined above
+
+### Not the product target
+- Multi-node replication and automatic failover for one shared logical database
+- Multi-tenant “one YarDB for the whole enterprise” deployments
+- Strongly consistent read-your-writes across independently owned files
 
 ## 🔧 Runtime Requirements
 
@@ -288,13 +306,14 @@ sar -n DEV 1
 - [ ] **Security**: Bind to private interfaces (or explicit public bind with PAT); enable Bearer PAT (`--pat` / `--pat-file`); add TLS at reverse proxy
 - [ ] **Monitoring**: Set up metrics collection and alerting
 - [ ] **Backup**: Configure regular backup procedures
+- [ ] **One DB per service**: Map each microservice to its own `yardb` process and `--file` (do not share a file across unrelated services)
 - [ ] **Single writer**: Ensure one process owns each database and document the stale-lock runbook
 - [ ] **Client limits**: Ensure clients keep request bodies within the 1 MiB limit
-- [ ] **High Availability**: Plan for redundancy and failover
-- [ ] **Performance**: Load test and tune resource limits
+- [ ] **Service redundancy**: If the service must stay up, plan redundancy at the *service* layer (multiple deployable units each with their own data ownership story), not by clustering one shared DB
+- [ ] **Performance**: Load test within the expected per-service dataset size
 - [ ] **Documentation**: Update runbooks and procedures
 
 ---
 
-**⚠️ Important**: YarDB is currently in development and should not be used in production environments without implementing the security and monitoring features outlined in the development roadmap.
+**⚠️ Important**: YarDB is still hardening for production (auth, TLS at the proxy, ops automation). Even when ready, treat it as **per-service persistence**, not as a drop-in replacement for a shared enterprise database.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,15 +2,17 @@
 
 ## Target deployment model
 
-YarDB is aimed at microservice persistence, not at monolithic or multi-tenant enterprise databases.
+YarDB is aimed at microservice persistence, not at monolithic or multi-tenant enterprise databases. Within each microservice, the aim is still **parallel and fault-tolerant YarDB instances** for that service’s dataset.
 
 | Assumption | Consequence |
 |------------|-------------|
-| One microservice owns one (or a few related) datasets | One `yardb` process and one `--file` database per service is the normal layout |
-| The service is the sole writer of its data | An exclusive `{database}.pid` lock and in-process write serialization are by design, not temporary gaps |
-| Scale comes from more services | Deploy another service with its own YarDB instance; do not expect one shared cluster for many domains |
+| One microservice owns one (or a few related) datasets | That service gets its own YarDB deployment; unrelated domains do not share it |
+| The service needs throughput and uptime | Run multiple `yardb` instances for that service (parallelism + fault tolerance), not only a single process |
+| Domains stay isolated | New domains → new services with their own YarDB; not one shared cluster for the whole enterprise |
 
-Keep each service’s database private to that service (loopback + reverse proxy, or network policy). Do not put unrelated domains into one file “for convenience.”
+Keep each service’s data private to that service (loopback + reverse proxy, or network policy). Do not put unrelated domains into one deployment “for convenience.”
+
+**Today vs aim:** each open database file still has one writer (exclusive `{database}.pid` lock). `yarproxy` can fan out HTTP to independent backends for development, but does not yet provide production-grade replication or failover. Parallel / fault-tolerant instances *per microservice* remain the product direction.
 
 ## 🚀 Production Readiness Status
 
@@ -19,13 +21,15 @@ Keep each service’s database private to that service (loopback + reverse proxy
 - ✅ Document storage and retrieval
 - ✅ OData query support
 - ⚠️ **Partial**: Bearer PAT MVP (data + admin for `/_*`), safe bind defaults (`127.0.0.1`, public bind requires PAT), liveness/readiness probes, minimum Prometheus `/metrics`, `correlation_id` tracing, exclusive database locking, startup validation, truncated-tail recovery, and a 1 MiB request limit
-- ❌ **Missing for hardened single-service deploys**: JWT/OAuth2, full RBAC, TLS at reverse proxy, richer ops automation
-- ❌ **Out of target model** (not a near-term product goal): multi-tenant shared databases, built-in multi-node HA for one logical store
+- ❌ **Missing for hardened per-service deploys**: JWT/OAuth2, full RBAC, TLS at reverse proxy, richer ops automation
+- ❌ **Missing for parallel / fault-tolerant instances per service**: production-grade replication, failover, and consistent multi-instance semantics (see below)
+- ❌ **Out of target model**: multi-tenant shared databases spanning unrelated domains
 
 **Production Requirements** (see [development roadmap](../docs/development.md)):
 - 🔐 **Security & Authentication** (data + admin PATs shipped; JWT/RBAC and TLS at reverse proxy still planned; safe bind defaults shipped)
 - 📊 **Monitoring & Observability** (minimum Prometheus `/metrics` shipped; richer labels / tracing planned; liveness/readiness probes shipped)
 - 🛡️ **Production Hardening** (graceful shutdown, resource limits)
+- 🔁 **Per-service parallelism & fault tolerance** (multiple instances for one microservice’s dataset)
 
 ## 🏗️ Building for Production
 
@@ -235,20 +239,19 @@ Point-in-time recovery is not implemented yet. Stop `yardb` before copying, expo
 ## 🚨 Availability & Scaling
 
 ### By design (microservice model)
-- **Single writer per database file**: Each `yardb` process owns one `--file`; exclusive `.pid` lock. Enough when one microservice owns that data.
-- **Scale out by service**: New domains get new services and new database files, not a bigger shared YarDB cluster.
-- **`yarproxy`**: Dev/test HTTP fan-out across independent backends only — not replication or HA (see [programs.md](programs.md#yarproxy---http-fan-out-proxy))
+- **Data ownership boundary**: one microservice → one YarDB deployment (its collections). Unrelated domains stay in other deployments.
+- **Aim per service**: several parallel, fault-tolerant `yardb` instances for that service’s dataset (throughput + failover).
+- **Today**: one writer per open database file (exclusive `.pid` lock); `yarproxy` is HTTP fan-out for independent backends in development — not production replication/HA yet (see [programs.md](programs.md#yarproxy---http-fan-out-proxy))
 - **Manual backup/compact**: `yarexport` / `yarimport` (no automated PITR)
 
-### Still useful for single-service production
-- Automated backups and retention for each service’s file
-- Clear stale-lock and restore runbooks
-- Reverse-proxy TLS, PAT (or later JWT), and probes already outlined above
+### Roadmap (per microservice)
+- Replication and automatic failover among instances that serve the same service dataset
+- Production-grade proxy: health checks, partial-failure reporting, and clear read/write consistency (including read-your-writes where required)
+- Automated backups and retention for each service deployment
 
 ### Not the product target
-- Multi-node replication and automatic failover for one shared logical database
-- Multi-tenant “one YarDB for the whole enterprise” deployments
-- Strongly consistent read-your-writes across independently owned files
+- Multi-tenant “one YarDB for the whole enterprise” spanning unrelated domains
+- Treating many domains as one shared logical database
 
 ## 🔧 Runtime Requirements
 
@@ -306,14 +309,14 @@ sar -n DEV 1
 - [ ] **Security**: Bind to private interfaces (or explicit public bind with PAT); enable Bearer PAT (`--pat` / `--pat-file`); add TLS at reverse proxy
 - [ ] **Monitoring**: Set up metrics collection and alerting
 - [ ] **Backup**: Configure regular backup procedures
-- [ ] **One DB per service**: Map each microservice to its own `yardb` process and `--file` (do not share a file across unrelated services)
-- [ ] **Single writer**: Ensure one process owns each database and document the stale-lock runbook
+- [ ] **One deployment per service**: Map each microservice to its own YarDB data (do not share a store across unrelated services)
+- [ ] **Instance lock awareness**: Until multi-instance semantics ship, ensure one process owns each open database file and document the stale-lock runbook
 - [ ] **Client limits**: Ensure clients keep request bodies within the 1 MiB limit
-- [ ] **Service redundancy**: If the service must stay up, plan redundancy at the *service* layer (multiple deployable units each with their own data ownership story), not by clustering one shared DB
+- [ ] **Parallelism & fault tolerance**: Plan for multiple instances per microservice when the service needs them; today use explicit ops patterns, and track the per-service HA roadmap above
 - [ ] **Performance**: Load test within the expected per-service dataset size
 - [ ] **Documentation**: Update runbooks and procedures
 
 ---
 
-**⚠️ Important**: YarDB is still hardening for production (auth, TLS at the proxy, ops automation). Even when ready, treat it as **per-service persistence**, not as a drop-in replacement for a shared enterprise database.
+**⚠️ Important**: YarDB is still hardening for production (auth, TLS at the proxy, multi-instance semantics, ops automation). Even when ready, treat it as per-service persistence with parallel/fault-tolerant instances *for that service* — not as a shared enterprise database for many domains.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -325,7 +325,7 @@ Current shipped work and verification totals are maintained only in [changelog.m
 - **Connection Pooling**: Efficient connection management
 - **Async I/O**: Non-blocking operations
 - **Memory Management**: Memory-mapped files, optimized storage
-- **Per-service capacity**: Faster single-writer paths and reader concurrency for one microservice’s dataset (scale by deploying more services with their own files, not by clustering one shared DB)
+- **Per-service parallelism & fault tolerance**: Multiple `yardb` instances for one microservice’s dataset (replication, failover, production-grade proxy semantics); new domains still get separate service deployments
 
 ##### Engine Reader/Writer Concurrency — ✅ implemented (Jul 2026)
 
@@ -349,9 +349,11 @@ The storage writer remains single-owner. A write lock covers file mutation and s
 
 ### Deployment model: microservice persistence
 - **Target**: Persistence behind one microservice (one or a few related datasets), not a multi-tenant enterprise store
-- **Unit of ownership**: One `yardb` process and one database file per service; exclusive `.pid` lock is intentional
-- **Scale-out**: More microservices → more YarDB instances/files; not one clustered database for many domains
-- **Out of scope as product goals**: Built-in multi-node replication/HA for a single shared logical database; monolith-style shared schemas across teams
+- **Unit of ownership**: One YarDB deployment per service (that service’s collections); unrelated domains stay isolated
+- **Per-service aim**: Parallel and fault-tolerant `yardb` instances for the same microservice (throughput + failover)
+- **Today**: One writer per open database file (exclusive `.pid` lock); `yarproxy` is not yet production HA
+- **Cross-service scale-out**: More microservices → more YarDB deployments; not one shared store for many domains
+- **Out of scope**: Multi-tenant “one YarDB for the enterprise”; monolith-style shared schemas across teams
 - **Operational detail**: See [deployment.md](deployment.md#target-deployment-model)
 
 ### Security Architecture

--- a/docs/development.md
+++ b/docs/development.md
@@ -325,7 +325,7 @@ Current shipped work and verification totals are maintained only in [changelog.m
 - **Connection Pooling**: Efficient connection management
 - **Async I/O**: Non-blocking operations
 - **Memory Management**: Memory-mapped files, optimized storage
-- **Horizontal Scaling**: Multi-node clustering support
+- **Per-service capacity**: Faster single-writer paths and reader concurrency for one microservice’s dataset (scale by deploying more services with their own files, not by clustering one shared DB)
 
 ##### Engine Reader/Writer Concurrency — ✅ implemented (Jul 2026)
 
@@ -346,6 +346,13 @@ The storage writer remains single-owner. A write lock covers file mutation and s
 - **Development Tools**: GUI admin interface, query debugger
 
 ## Architecture Decisions
+
+### Deployment model: microservice persistence
+- **Target**: Persistence behind one microservice (one or a few related datasets), not a multi-tenant enterprise store
+- **Unit of ownership**: One `yardb` process and one database file per service; exclusive `.pid` lock is intentional
+- **Scale-out**: More microservices → more YarDB instances/files; not one clustered database for many domains
+- **Out of scope as product goals**: Built-in multi-node replication/HA for a single shared logical database; monolith-style shared schemas across teams
+- **Operational detail**: See [deployment.md](deployment.md#target-deployment-model)
 
 ### Security Architecture
 - **TLS Proxy Pattern**: Transport security handled externally for separation of concerns

--- a/docs/development.md
+++ b/docs/development.md
@@ -325,7 +325,7 @@ Current shipped work and verification totals are maintained only in [changelog.m
 - **Connection Pooling**: Efficient connection management
 - **Async I/O**: Non-blocking operations
 - **Memory Management**: Memory-mapped files, optimized storage
-- **Per-service parallelism & fault tolerance**: Multiple `yardb` instances for one microservice’s dataset (replication, failover, production-grade proxy semantics); new domains still get separate service deployments
+- **Parallelism & fault tolerance (main target)**: Multiple `yardb` instances for one owner’s dataset — typically one microservice (replication, failover, production-grade proxy semantics); prefer separate deployments when domains are independent
 
 ##### Engine Reader/Writer Concurrency — ✅ implemented (Jul 2026)
 
@@ -347,13 +347,12 @@ The storage writer remains single-owner. A write lock covers file mutation and s
 
 ## Architecture Decisions
 
-### Deployment model: microservice persistence
-- **Target**: Persistence behind one microservice (one or a few related datasets), not a multi-tenant enterprise store
-- **Unit of ownership**: One YarDB deployment per service (that service’s collections); unrelated domains stay isolated
-- **Per-service aim**: Parallel and fault-tolerant `yardb` instances for the same microservice (throughput + failover)
+### Deployment model: mainly microservice persistence
+- **Main target**: Persistence for one owner with one or a few related datasets — typically a microservice. Other uses are fine when they match that shape
+- **Unit of ownership**: Prefer one YarDB deployment per owner; separate deployments when domains are independent
+- **Aim per owner**: Parallel and fault-tolerant `yardb` instances for the same dataset (throughput + failover)
 - **Today**: One writer per open database file (exclusive `.pid` lock); `yarproxy` is not yet production HA
-- **Cross-service scale-out**: More microservices → more YarDB deployments; not one shared store for many domains
-- **Out of scope**: Multi-tenant “one YarDB for the enterprise”; monolith-style shared schemas across teams
+- **Weaker fit**: One shared store for many unrelated domains (monolith / multi-tenant enterprise style) — not the main design target
 - **Operational detail**: See [deployment.md](deployment.md#target-deployment-model)
 
 ### Security Architecture

--- a/docs/programs.md
+++ b/docs/programs.md
@@ -4,16 +4,16 @@ This document describes the various programs included in the YarDB project.
 
 ## yardb - Database Server
 
-The main database server that provides a RESTful HTTP API for document storage and retrieval.
+The main database server that provides a RESTful HTTP API for document storage and retrieval. It is meant as per-microservice persistence: one process, one database file, and the collections that service owns — not as a shared enterprise database for many domains.
 
 ### Purpose
 
 `yardb` is the core database server that:
 - Accepts HTTP/1.1 requests
-- Stores documents in FSON-encoded format
+- Stores documents in FSON-encoded format (one `--file` per service is the usual layout)
 - Provides RESTful CRUD operations
-- Manages collections and indexing
-- Handles concurrent requests via multi-threaded architecture
+- Manages collections and indexing for that service’s dataset
+- Handles concurrent requests in-process (shared locks for reads; exclusive write lock; exclusive `.pid` ownership of the file)
 
 ### Usage
 
@@ -29,10 +29,10 @@ yardb [--help] [--clog] [--slog_level=<level>] [--file=<name>] [--bind=<host>] [
   - Binding to `0.0.0.0` or `::` **requires** `--pat` or `--pat-file`
 
 - `--file=<name>` - Database file path (default: `yar.db`)
-  - The database file stores all collections and documents
+  - The database file stores all collections and documents for this instance
   - If the file doesn't exist, it will be created
-  - Multiple instances can use different files for separate databases
-  - Opening creates an exclusive `{file}.pid` lock; verify no live owner before manually removing a stale lock
+  - Give each microservice its own file (and usually its own `yardb` process); do not share one file across unrelated services
+  - Opening creates an exclusive `{file}.pid` lock (single writer by design); verify no live owner before manually removing a stale lock
   - Startup recovers incomplete tails automatically and refuses structurally corrupt files
 
 - `--clog` - Redirect logging to console (stdout/stderr) instead of syslog

--- a/docs/programs.md
+++ b/docs/programs.md
@@ -4,7 +4,7 @@ This document describes the various programs included in the YarDB project.
 
 ## yardb - Database Server
 
-The main database server that provides a RESTful HTTP API for document storage and retrieval. It is meant as per-microservice persistence: the collections that service owns, with parallel and fault-tolerant instances as the aim for that service — not as a shared enterprise database for many domains.
+The main database server that provides a RESTful HTTP API for document storage and retrieval. It is mainly targeted at per-microservice persistence (one owner’s collections, with parallel and fault-tolerant instances as the aim). Other uses are fine when they match that shape; a shared store for many unrelated domains is a weaker fit.
 
 ### Purpose
 
@@ -31,9 +31,9 @@ yardb [--help] [--clog] [--slog_level=<level>] [--file=<name>] [--bind=<host>] [
 - `--file=<name>` - Database file path (default: `yar.db`)
   - The database file stores all collections and documents for this instance
   - If the file doesn't exist, it will be created
-  - Give each microservice its own data store; do not share one file across unrelated services
+  - Prefer one data store per owner (e.g. per microservice); sharing one file across unrelated domains is a weaker fit
   - Opening creates an exclusive `{file}.pid` lock (one writer per open file today); verify no live owner before manually removing a stale lock
-  - Parallel / fault-tolerant multi-instance operation for the same service is the product aim; see [deployment.md](deployment.md#availability--scaling)
+  - Parallel / fault-tolerant multi-instance operation for the same owner’s dataset is the product aim; see [deployment.md](deployment.md#availability--scaling)
   - Startup recovers incomplete tails automatically and refuses structurally corrupt files
 
 - `--clog` - Redirect logging to console (stdout/stderr) instead of syslog
@@ -400,7 +400,7 @@ Cases: `crud`, `put`, `patch`, `count`, `top_skip`, `orderby`, `select`, `filter
 
 ## yarproxy - HTTP Fan-out Proxy
 
-Forwards HTTP requests to multiple independent `yardb` backends. Each backend has its own database file. The long-term aim is parallel, fault-tolerant instances *per microservice*; `yarproxy` today is only a development fan-out, not that production path.
+Forwards HTTP requests to multiple independent `yardb` backends. Each backend has its own database file. The long-term aim (mainly for the microservice case) is parallel, fault-tolerant instances per owner; `yarproxy` today is only a development fan-out, not that production path.
 
 ### Purpose
 

--- a/docs/programs.md
+++ b/docs/programs.md
@@ -4,16 +4,16 @@ This document describes the various programs included in the YarDB project.
 
 ## yardb - Database Server
 
-The main database server that provides a RESTful HTTP API for document storage and retrieval. It is meant as per-microservice persistence: one process, one database file, and the collections that service owns — not as a shared enterprise database for many domains.
+The main database server that provides a RESTful HTTP API for document storage and retrieval. It is meant as per-microservice persistence: the collections that service owns, with parallel and fault-tolerant instances as the aim for that service — not as a shared enterprise database for many domains.
 
 ### Purpose
 
 `yardb` is the core database server that:
 - Accepts HTTP/1.1 requests
-- Stores documents in FSON-encoded format (one `--file` per service is the usual layout)
+- Stores documents in FSON-encoded format for one service’s dataset
 - Provides RESTful CRUD operations
 - Manages collections and indexing for that service’s dataset
-- Handles concurrent requests in-process (shared locks for reads; exclusive write lock; exclusive `.pid` ownership of the file)
+- Handles concurrent requests in-process (shared locks for reads; exclusive write lock; exclusive `.pid` ownership of each open file today)
 
 ### Usage
 
@@ -31,8 +31,9 @@ yardb [--help] [--clog] [--slog_level=<level>] [--file=<name>] [--bind=<host>] [
 - `--file=<name>` - Database file path (default: `yar.db`)
   - The database file stores all collections and documents for this instance
   - If the file doesn't exist, it will be created
-  - Give each microservice its own file (and usually its own `yardb` process); do not share one file across unrelated services
-  - Opening creates an exclusive `{file}.pid` lock (single writer by design); verify no live owner before manually removing a stale lock
+  - Give each microservice its own data store; do not share one file across unrelated services
+  - Opening creates an exclusive `{file}.pid` lock (one writer per open file today); verify no live owner before manually removing a stale lock
+  - Parallel / fault-tolerant multi-instance operation for the same service is the product aim; see [deployment.md](deployment.md#availability--scaling)
   - Startup recovers incomplete tails automatically and refuses structurally corrupt files
 
 - `--clog` - Redirect logging to console (stdout/stderr) instead of syslog
@@ -399,15 +400,15 @@ Cases: `crud`, `put`, `patch`, `count`, `top_skip`, `orderby`, `select`, `filter
 
 ## yarproxy - HTTP Fan-out Proxy
 
-Forwards HTTP requests to multiple independent `yardb` backends. Each backend has its own database file.
+Forwards HTTP requests to multiple independent `yardb` backends. Each backend has its own database file. The long-term aim is parallel, fault-tolerant instances *per microservice*; `yarproxy` today is only a development fan-out, not that production path.
 
 ### Purpose
 
-`yarproxy` is a **thin HTTP forwarder** for development and testing:
+`yarproxy` is a thin HTTP forwarder for development and testing:
 - **Read fan-out** (GET, HEAD): round-robin — one backend per request
 - **Write fan-out** (POST, PUT, PATCH, DELETE): same request sent to every backend
 
-It does **not** implement database replication, leader election, or conflict resolution.
+It does not implement database replication, leader election, or conflict resolution. Those belong to the per-service multi-instance roadmap in [deployment.md](deployment.md#availability--scaling).
 
 ### Usage
 

--- a/docs/programs.md
+++ b/docs/programs.md
@@ -473,7 +473,7 @@ yarproxy --clog --replica=http://db1:2112 --replica=http://db2:2112 --replica=ht
 - **Read experiments**: Observe round-robin across independent datasets
 - **Write fan-out demos**: Broadcast creates/updates to several empty databases started together
 
-Not suitable for: production HA, guaranteed replication, or strongly consistent reads after writes.
+Not suitable yet for: production HA, guaranteed replication, or strongly consistent reads after writes for a microservice’s dataset.
 
 ### Smoke tests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Position YarDB as **mainly targeted** at microservice persistence, with parallel and fault-tolerant instances as the aim for that primary case — without reading as “microservices only.”

## Changes

- **README.md** — Opening and intended use use “mainly targeted”; other matching uses are fine; enterprise shared stores are a “weaker fit,” not forbidden
- **docs/deployment.md** — Target model / availability / checklist use primary-fit vs weaker-fit language; drop “out of target model”
- **docs/programs.md**, **docs/development.md**, **docs/README.md** — Same tone throughout

## Framing

| Phrase | Meaning |
|--------|---------|
| Mainly targeted | Primary design sweet spot (microservices) |
| Weaker fit | Shared multi-domain / enterprise-style stores — not the focus, still possible if you accept the shape |
| Per-owner aim | Parallel + fault-tolerant instances for one owner’s dataset |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f747b-5e12-7508-b412-9f779e103bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f747b-5e12-7508-b412-9f779e103bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

