### PR TITLE
feat: add boolean not operator to OData $filter

### DIFF
--- a/YarDB/yar-httpd.test.c++
+++ b/YarDB/yar-httpd.test.c++
@@ -1417,6 +1417,67 @@ auto test_set()
             }
         };
 
+        section("GET with $filter - not contains(email, '@example')") = [setup]
+        {
+            auto [status, reason, headers, response_body] = make_request(
+                setup->port(),
+                "GET"s,
+                "/users3?$filter=not%20contains(email,'@example')"s,
+                ""s
+            );
+
+            require_eq(status, "200"s);
+            require_eq(reason, "OK"s);
+
+            auto documents = json::parse(response_body);
+            require_true(documents.is_array());
+            const auto& items = documents.get<object::array>();
+            require_true(items.size() >= 1);
+
+            for(const auto& item : items)
+            {
+                if(not item.has("email"s))
+                    continue;
+                const string email = item["email"s];
+                require_true(email.find("@example"s) == std::string::npos);
+            }
+        };
+
+        section("GET with $filter - not status eq 'deleted'") = [setup]
+        {
+            auto [post_status, post_reason, post_headers, post_body] = make_request(
+                setup->port(),
+                "POST"s,
+                "/usersnot"s,
+                R"({"name":"Keep","status":"active"})"s
+            );
+            require_eq(post_status, "201"s);
+            std::this_thread::sleep_for(100ms);
+
+            auto [post2_status, post2_reason, post2_headers, post2_body] = make_request(
+                setup->port(),
+                "POST"s,
+                "/usersnot"s,
+                R"({"name":"Drop","status":"deleted"})"s
+            );
+            require_eq(post2_status, "201"s);
+            std::this_thread::sleep_for(100ms);
+
+            auto [status, reason, headers, response_body] = make_request(
+                setup->port(),
+                "GET"s,
+                "/usersnot?$filter=not%20status%20eq%20'deleted'"s,
+                ""s
+            );
+
+            require_eq(status, "200"s);
+            auto documents = json::parse(response_body);
+            require_true(documents.is_array());
+            const auto& items = documents.get<object::array>();
+            require_eq(items.size(), 1u);
+            require_eq(items[0]["name"s].get<string>(), "Keep"s);
+        };
+
         section("GET with $filter - endswith(path, '.pdf')") = [setup]
         {
             // Create test documents with different file paths

--- a/YarDB/yar-odata.c++m
+++ b/YarDB/yar-odata.c++m
@@ -180,6 +180,7 @@ export struct string_filter
     std::string_view function;  // "startswith", "contains", "endswith" (string literals)
     std::string field;          // Field name (copied; may be nested path)
     std::string value;          // Filter value (owned so OData '' escapes can be unescaped)
+    bool negated = false;       // true for `not contains(...)` / `not startswith(...)` / …
 };
 
 // One branch of an OData OR expression (selector AND string filters within the branch)
@@ -602,6 +603,85 @@ inline auto make_in_selector(std::string_view field, std::span<const xson::objec
 
 using filter_clause = std::pair<xson::object, std::vector<string_filter>>;
 
+// Negate one operator-constraint leaf ($eq/$ne/$gt/… or bare equality value).
+inline xson::object negate_constraint_leaf(const xson::object& leaf)
+{
+    if(is_operator_constraint_map(leaf))
+    {
+        if(leaf.has("$eq"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$ne"s, leaf["$eq"s]}};
+        if(leaf.has("$ne"s) and leaf.get<db::object::map>().size() == 1)
+            return leaf["$ne"s]; // bare equality
+        if(leaf.has("$gt"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$lte"s, leaf["$gt"s]}};
+        if(leaf.has("$gte"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$lt"s, leaf["$gte"s]}};
+        if(leaf.has("$lt"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$gte"s, leaf["$lt"s]}};
+        if(leaf.has("$lte"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$gt"s, leaf["$lte"s]}};
+        if(leaf.has("$in"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$nin"s, leaf["$in"s]}};
+        if(leaf.has("$nin"s) and leaf.get<db::object::map>().size() == 1)
+            return xson::object{{"$in"s, leaf["$nin"s]}};
+
+        // Multi-op maps are exploded before negate; fall back to impossible→empty.
+        throw std::invalid_argument{"Cannot negate compound operator map in $filter"};
+    }
+
+    // Bare equality value → $ne
+    return xson::object{{"$ne"s, leaf}};
+}
+
+// Walk a selector into path + leaf atoms (AND conjuncts).
+inline void collect_selector_atoms(
+    const xson::object& node,
+    std::string_view path_prefix,
+    std::vector<std::pair<std::string, xson::object>>& atoms)
+{
+    if(not node.has_objects())
+    {
+        if(path_prefix.empty())
+            return;
+        atoms.emplace_back(std::string{path_prefix}, node);
+        return;
+    }
+
+    if(is_operator_constraint_map(node))
+    {
+        if(path_prefix.empty())
+            throw std::invalid_argument{"Invalid filter selector"};
+
+        for(const auto& [op, value] : node.get<db::object::map>())
+            atoms.emplace_back(std::string{path_prefix}, xson::object{{op, value}});
+        return;
+    }
+
+    for(const auto& [key, value] : node.get<db::object::map>())
+    {
+        const auto path = path_prefix.empty()
+            ? std::string{key}
+            : std::string{path_prefix} + "/"s + key;
+        collect_selector_atoms(value, path, atoms);
+    }
+}
+
+inline filter_branch negate_string_filter(string_filter filter)
+{
+    filter.negated = not filter.negated;
+    return filter_branch{xson::object{}, {std::move(filter)}};
+}
+
+inline filter_branch negate_selector_atom(std::string path, const xson::object& leaf)
+{
+    auto selector = xson::object{};
+    set_nested_selector_leaf(selector, path, negate_constraint_leaf(leaf));
+    return filter_branch{std::move(selector), {}};
+}
+
+// Forward declaration — defined with parse_filter below.
+inline parsed_filter negate_parsed_filter(parsed_filter filter);
+
 // Strip balanced outer parentheses that wrap an entire expression.
 // OData clients commonly group with (name eq 'Alice'); without this, the
 // leaf parser treats the field as "(name" and the value as "'Alice')" and
@@ -889,10 +969,44 @@ inline parsed_filter and_parsed_filters(parsed_filter left, parsed_filter right)
     return parsed_from_branches(std::move(combined));
 }
 
+// Negate a parsed filter via operator rewrites and De Morgan (not (A and B) → not A or not B).
+inline parsed_filter negate_parsed_filter(parsed_filter filter)
+{
+    if(filter.has_or())
+    {
+        // not (A or B) = not A and not B
+        auto merged = negate_parsed_filter(
+            parsed_from_branches({std::move(filter.or_branches.front())}));
+        for(auto& branch : filter.or_branches | std::views::drop(1))
+        {
+            merged = and_parsed_filters(
+                std::move(merged),
+                negate_parsed_filter(parsed_from_branches({std::move(branch)})));
+        }
+        return merged;
+    }
+
+    // not (conjuncts) = OR of negated atoms
+    auto branches = std::vector<filter_branch>{};
+    auto atoms = std::vector<std::pair<std::string, xson::object>>{};
+    collect_selector_atoms(filter.and_selector, ""sv, atoms);
+
+    for(auto& [path, leaf] : atoms)
+        branches.push_back(negate_selector_atom(std::move(path), leaf));
+
+    for(auto& string_filter : filter.and_string_filters)
+        branches.push_back(negate_string_filter(std::move(string_filter)));
+
+    if(branches.empty())
+        throw std::invalid_argument{"Cannot negate empty filter expression"};
+
+    return parsed_from_branches(std::move(branches));
+}
+
 // Parse OData $filter expression
-// Supports: comparisons, in, string functions, and (AND), or (OR — OData precedence: AND before OR)
-// Grouping parentheses are honored: top-level and/or splits ignore nested groups, and
-// `(A or B) and C` is rewritten to `(A and C) or (B and C)` for the flat OR-branch model.
+// Supports: comparisons, in, string functions, not, and (AND), or (OR)
+// Precedence: not > and > or. Grouping parentheses are honored; top-level and/or
+// splits ignore nested groups, and `(A or B) and C` distributes to OR branches.
 export inline parsed_filter parse_filter(std::string_view filter_expr)
 {
     auto expr = strip_outer_parens(filter_expr);
@@ -930,6 +1044,17 @@ export inline parsed_filter parse_filter(std::string_view filter_expr)
             merged = and_parsed_filters(std::move(merged), parse_filter(part));
 
         return merged;
+    }
+
+    // Unary not (binds tighter than and/or; handled after those splits).
+    if(expr.starts_with("not "sv) or expr.starts_with("not("sv))
+    {
+        auto rest = expr.substr(3);
+        if(rest.starts_with(' '))
+            rest = utils::trim(rest);
+        if(rest.empty())
+            throw std::invalid_argument{"Invalid filter expression: "s + std::string{expr}};
+        return negate_parsed_filter(parse_filter(rest));
     }
 
     auto [selector, string_filters] = parse_filter_leaf(expr);
@@ -1007,7 +1132,10 @@ export inline void lower_startswith_filters(
 
     for(const auto& filter : string_filters)
     {
-        if(filter.function != "startswith"sv or filter.field.contains('/'))
+        // Negated startswith cannot use a prefix range (would exclude the wrong set).
+        if(filter.function != "startswith"sv
+            or filter.negated
+            or filter.field.contains('/'))
         {
             remaining.push_back(filter);
             continue;
@@ -1044,17 +1172,27 @@ inline auto document_matches_string_filters(
     return std::ranges::all_of(filters, [&](const string_filter& filter)
     {
         const auto field = get_string_field_by_path(doc, filter.field);
-        if(not field)
-            return false;
+        auto matches = false;
+        if(field)
+        {
+            if(filter.function == "startswith"sv)
+                matches = field->starts_with(filter.value);
+            else if(filter.function == "contains"sv)
+                matches = field->contains(filter.value);
+            else if(filter.function == "endswith"sv)
+                matches = field->ends_with(filter.value);
+            else
+                throw std::logic_error{"Unknown string filter function: "s + std::string{filter.function}};
+        }
+        else if(filter.function != "startswith"sv
+            and filter.function != "contains"sv
+            and filter.function != "endswith"sv)
+        {
+            throw std::logic_error{"Unknown string filter function: "s + std::string{filter.function}};
+        }
 
-        if(filter.function == "startswith"sv)
-            return field->starts_with(filter.value);
-        if(filter.function == "contains"sv)
-            return field->contains(filter.value);
-        if(filter.function == "endswith"sv)
-            return field->ends_with(filter.value);
-
-        throw std::logic_error{"Unknown string filter function: "s + std::string{filter.function}};
+        // Missing field → false for positive string ops; not contains(...) → true.
+        return filter.negated ? not matches : matches;
     });
 }
 

--- a/YarDB/yar-odata.test.c++
+++ b/YarDB/yar-odata.test.c++
@@ -23,6 +23,16 @@ inline auto parse_and_filter(std::string_view expr)
     return std::make_pair(parsed.and_selector, parsed.and_string_filters);
 }
 
+inline auto filter_by_parsed(const object& docs, const parsed_filter& parsed)
+{
+    if(parsed.has_or())
+        return filter_documents_by_or(docs, parsed.or_branches);
+
+    const auto branches = std::vector<filter_branch>{
+        filter_branch{parsed.and_selector, parsed.and_string_filters}};
+    return filter_documents_by_or(docs, branches);
+}
+
 auto register_odata_tests()
 {
     using namespace tester::bdd;
@@ -1196,6 +1206,97 @@ auto register_odata_tests()
                     require_eq(items.size(), 2u);
                     require_eq(items[0]["name"s].get<string>(), "Alice"s);
                     require_eq(items[1]["name"s].get<string>(), "Bob"s);
+                };
+            };
+        };
+    };
+
+    scenario("parse_filter not operator matches documents, [yardb]") = []
+    {
+        given("Documents with name, email, and status") = []
+        {
+            auto docs = object{object::array{
+                object{{"_id"s, 1ll}, {"name"s, "Alice"s}, {"email"s, "alice@example.com"s}, {"status"s, "active"s}},
+                object{{"_id"s, 2ll}, {"name"s, "Bob"s}, {"email"s, "bob@test.com"s}, {"status"s, "deleted"s}},
+                object{{"_id"s, 3ll}, {"name"s, "Charlie"s}, {"email"s, "charlie@example.com"s}, {"status"s, "active"s}},
+                object{{"_id"s, 4ll}, {"name"s, "Dana"s}, {"status"s, "active"s}}
+            }};
+
+            when("Filter is not status eq 'deleted'") = [docs]
+            {
+                then("Rewrites to ne and excludes deleted") = [docs]
+                {
+                    const auto [selector, filters] = parse_and_filter("not status eq 'deleted'"sv);
+                    require_true(filters.empty());
+                    require_true(selector["status"s].has("$ne"s));
+
+                    const auto result = filter_by_parsed(docs, parse_filter("not status eq 'deleted'"sv));
+                    const auto& items = result.get<object::array>();
+                    require_eq(items.size(), 3u);
+                };
+            };
+
+            when("Filter is not contains(email, '@example')") = [docs]
+            {
+                then("Keeps docs without the substring including missing email") = [docs]
+                {
+                    const auto [selector, filters] = parse_and_filter("not contains(email, '@example')"sv);
+                    require_true(selector.empty());
+                    require_eq(filters.size(), 1u);
+                    require_true(filters[0].negated);
+
+                    const auto result = filter_by_parsed(
+                        docs, parse_filter("not contains(email, '@example')"sv));
+                    const auto& items = result.get<object::array>();
+                    require_eq(items.size(), 2u);
+                    require_eq(items[0]["name"s].get<string>(), "Bob"s);
+                    require_eq(items[1]["name"s].get<string>(), "Dana"s);
+                };
+            };
+
+            when("Filter is not (status eq 'active' and contains(email, '@example'))") = [docs]
+            {
+                then("Applies De Morgan across comparison and string filter") = [docs]
+                {
+                    const auto parsed = parse_filter(
+                        "not (status eq 'active' and contains(email, '@example'))"sv);
+                    require_true(parsed.has_or());
+
+                    const auto result = filter_by_parsed(docs, parsed);
+                    const auto& items = result.get<object::array>();
+                    // Alice/Charlie match the inner AND → excluded; Bob and Dana remain.
+                    require_eq(items.size(), 2u);
+                    require_eq(items[0]["name"s].get<string>(), "Bob"s);
+                    require_eq(items[1]["name"s].get<string>(), "Dana"s);
+                };
+            };
+
+            when("Filter is not status eq 'deleted' and contains(email, '@example')") = [docs]
+            {
+                then("not binds tighter than and") = [docs]
+                {
+                    const auto result = filter_by_parsed(
+                        docs,
+                        parse_filter("not status eq 'deleted' and contains(email, '@example')"sv));
+                    const auto& items = result.get<object::array>();
+                    require_eq(items.size(), 2u);
+                    require_eq(items[0]["name"s].get<string>(), "Alice"s);
+                    require_eq(items[1]["name"s].get<string>(), "Charlie"s);
+                };
+            };
+
+            when("Filter is not not contains(name, 'li')") = [docs]
+            {
+                then("Double negation restores positive contains") = [docs]
+                {
+                    const auto [selector, filters] = parse_and_filter("not not contains(name, 'li')"sv);
+                    require_eq(filters.size(), 1u);
+                    require_false(filters[0].negated);
+
+                    const auto result = filter_by_parsed(
+                        docs, parse_filter("not not contains(name, 'li')"sv));
+                    const auto& items = result.get<object::array>();
+                    require_eq(items.size(), 2u); // Alice, Charlie
                 };
             };
         };

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ For planned work see [development.md](development.md#development-roadmap). Histo
 
 | Item | Summary |
 |------|---------|
+| **Boolean `not` in `$filter`** | `not status eq 'deleted'`, `not contains(email,'@example')`, De Morgan for `not (A and B)` / `not (A or B)`; precedence `not` > `and` > `or` |
 | **`$apply` groupby/aggregate (v1)** | `GET /orders?$apply=groupby((status),aggregate(amount with sum as Total))` — also `average`/`min`/`max` and whole-set `aggregate(...)`; optional `$filter` first; see [odata.md](odata.md) |
 | **Same-field AND `$filter`** | `age eq 10 and age gt 5` (and contradictory `status eq 'a' and status eq 'b'`) keep every predicate instead of last-write-wins clobbering earlier constraints |
 | **Same-operator range AND** | `age gt 20 and age gt 10` keeps the tighter bound (`$gt:20`) instead of last-write-wins loosening the filter |

--- a/docs/development.md
+++ b/docs/development.md
@@ -263,7 +263,7 @@ Current shipped work and verification totals are maintained only in [changelog.m
 
 #### 0. 📊 OData query surface
 - **Checklist**: [odata.md](odata.md) — supported today vs pipeline
-- **`$filter`**: ✅ largely complete (`eq`/`ne`/ranges/`and`/`or`/`in`/nested paths; index-backed `startswith`; post-filter `contains`/`endswith`)
+- **`$filter`**: ✅ largely complete (`eq`/`ne`/ranges/`not`/`and`/`or`/`in`/nested paths; index-backed `startswith`; post-filter `contains`/`endswith`)
 - **`$apply` groupby/aggregate**: ✅ v1 shipped — `groupby((field),aggregate(amount with sum as Total))` (+ `average`/`min`/`max`); optional `$filter` before aggregate
 - **Next**: deeper `$expand` (overrides, multi-valued refs) beyond `{singular}_id`; richer `$apply` (multi-key, transform chains)
 

--- a/docs/odata.md
+++ b/docs/odata.md
@@ -21,11 +21,11 @@ YarDB implements a practical **subset** of OData 4.x for document collections ov
 | Feature | Notes |
 |---------|--------|
 | Comparisons | `eq`, `ne`, `gt`, `ge`, `lt`, `le` |
-| Logic | `and`, `or` (AND binds tighter than OR) |
+| Logic | `not`, `and`, `or` (precedence: `not` > `and` > `or`) |
 | `in` | Strings or numbers |
 | Nested paths | `Customer/Country eq 'USA'` |
-| `startswith` | Index-backed on top-level secondary keys |
-| `contains` / `endswith` | Post-filter only |
+| `startswith` | Index-backed on top-level secondary keys (not when negated) |
+| `contains` / `endswith` | Post-filter only; `not contains` / `not endswith` supported |
 
 ### Metadata & format
 
@@ -55,7 +55,6 @@ Tracked here and in [development.md](development.md#development-roadmap). Order 
 | `$search` | `$search=wireless` |
 | `$compute` | `$compute=Price mul Qty as LineTotal` |
 | `$skiptoken` / `@odata.nextLink` | Server-driven paging |
-| Boolean `not` in `$filter` | `not (status eq 'deleted')` |
 | Collection lambdas | `Lines/any(l:l/Qty gt 0)` |
 | Richer string/date functions | `indexof`, `tolower`, `year(...)` |
 | `$batch` | `POST /$batch` |

--- a/docs/programs.md
+++ b/docs/programs.md
@@ -171,13 +171,13 @@ YarDB implements OData-compliant query parameters for advanced querying:
 
 - **`$filter=expression`** - Filter documents
   - Comparison operators: `eq`, `ne`, `gt`, `ge`, `lt`, `le`
-  - Logical operators: `and`, `or` (OData precedence: AND before OR)
+  - Logical operators: `not`, `and`, `or` (OData precedence: `not` > `and` > `or`)
   - `in` operator: `status in ('active','pending')` or `id in (1, 2, 3)`
   - Nested paths: `Customer/Country eq 'USA'`, `startswith(Customer/Name, 'Ac')` (nested objects only)
   - String functions:
     - `startswith(field, 'prefix')` — index-backed when `field` is a top-level secondary index key; otherwise post-filter
     - `contains(field, 'substring')`, `endswith(field, 'suffix')` — post-filter only
-  - Example: `GET /users?$filter=status ne 'deleted'`, `GET /users?$filter=startswith(name,'A')` (requires `name` indexed)
+  - Example: `GET /users?$filter=status ne 'deleted'`, `GET /users?$filter=not%20contains(email,'@example')`, `GET /users?$filter=startswith(name,'A')` (requires `name` indexed)
   - Indexed primitive types remain distinct (`1`, `1.0`, `"1"`, and `true` are separate keys); numeric ranges use numeric ordering
 
 - **`$select=field1,field2`** - Project specific fields


### PR DESCRIPTION
## Summary
- Add unary `not` to `$filter` with OData precedence (`not` > `and` > `or`)
- Rewrite comparisons (`eq`↔`ne`, ranges, `in`↔`$nin`); De Morgan for grouped `and`/`or`
- Support negated string functions (`not contains` / `startswith` / `endswith`); missing field → true for negated contains

## Test plan
- [x] `./tools/CB.sh debug test --jsonl=failures --tags='\[yardb\]'` (527/527)
- [x] Unit scenarios for rewrite, De Morgan, precedence, double negation
- [x] HTTP cases for `not contains` and `not status eq`


Made with [Cursor](https://cursor.com)