### PR TITLE
fix(tests): ephemeral HTTP ports + net handler drain for --jobs

### DIFF
--- a/YarDB/yar-httpd.c++m
+++ b/YarDB/yar-httpd.c++m
@@ -202,6 +202,13 @@ public:
         return m_state.load();
     }
 
+    // Port the listen socket is bound to (0 before listen / after stop).
+    // Useful when start() was given "0" so the OS picks an ephemeral port.
+    std::uint16_t bound_port()
+    {
+        return m_server.bound_port();
+    }
+
     // For backward compatibility - blocks forever
     void listen()
     {

--- a/YarDB/yar-httpd.test.c++
+++ b/YarDB/yar-httpd.test.c++
@@ -22,7 +22,9 @@ using namespace yar::http::details;
 class fixture
 {
 public:
-    fixture(string_view f) : file{f}, m_port{"21120"s}
+    // Bind port "0" so each parallel top-level case gets an OS-assigned
+    // ephemeral port. A fixed port (e.g. 21120) collides under --jobs>1.
+    fixture(string_view f) : file{f}, m_port{"0"s}
     {
         // Set logging app name and sd_id for tests (using instance methods)
         slog.app_name("yardb")
@@ -37,8 +39,18 @@ public:
         fs.close();
         server = std::make_unique<yar::http::rest_api_server>(file, m_port);
         server->start();
-        // Wait longer for server to start and bind to port
-        std::this_thread::sleep_for(1000ms);
+        // Wait until listen() has bound and published the ephemeral port.
+        for(auto attempt = 0; attempt < 200; ++attempt)
+        {
+            const auto bound = server->bound_port();
+            if(bound != 0)
+            {
+                m_port = std::to_string(bound);
+                return;
+            }
+            std::this_thread::sleep_for(10ms);
+        }
+        throw std::runtime_error{"HTTP fixture failed to bind an ephemeral port"};
     }
 
     const std::string& port() const { return m_port; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Enable stable `test_runner --jobs=N` for the YarDB suite.

Issues that blocked parallel runs / CI:

1. **Port collisions** — HTTP fixtures all bound port `21120`.
2. **Heap UAF under `--jobs>2`** — detached `http::server` handlers in `deps/net` could outlive `listen()` after `stop()` (MCP SSE `erase_session` vs destroyed session map).
3. **CI `yarproxy-smoke` hang** — waiting for those handlers without waking idle keep-alive sockets made yardb hang on SIGTERM while yarproxy still held pooled connections (`partial_backend_drain` → 10m job cancel).

## Fixes
- **YarDB:** `rest_api_server::bound_port()`; HTTP fixture binds `"0"`, waits for the OS-assigned port.
- **net** ([`794770f`](https://github.com/ruoka/net4cpp/commit/794770ff033ab5d2dc81dc4d2f2e272091b2624c)):
  - Track in-flight handlers; wait on every `listen()` exit path.
  - `stop()` `shutdown()`s accepted client sockets so idle keep-alive handlers unblock, then the wait completes.

## Verification
| Check | Result |
|------|--------|
| `[yardb] --jobs=4` | 625/625 (local stress) |
| `[yardb] --jobs=10` | 625/625 × 10 |
| `tests/yarproxy/smoke.sh` | passed (incl. `partial_backend_drain`) |

## Note
Keep `NET_DISABLE_NETWORK_TESTS=1` for YarDB scoped runs (net static-init multicast probe).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb927-928c-7ecf-bf7a-a3573c66e727?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb927-928c-7ecf-bf7a-a3573c66e727&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

